### PR TITLE
Fix incorrect Boolean in JAMTestHelper.swift

### DIFF
--- a/JAM Test Helper/JAMTestHelper.swift
+++ b/JAM Test Helper/JAMTestHelper.swift
@@ -68,7 +68,7 @@ extension XCTestCase {
             if (NSDate.timeIntervalSinceReferenceDate() - startTime > 2.0) {
                 raiseTimeOutException(failureMessage)
             }
-            CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, Boolean(0))
+            CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, Bool(0))
         }
     }
 


### PR DESCRIPTION
Build was broken for me when it expected Bool instead of Boolean.
