### PR TITLE
Make JAMTestHelper extension public

### DIFF
--- a/JAM Test Helper/JAMTestHelper.swift
+++ b/JAM Test Helper/JAMTestHelper.swift
@@ -17,7 +17,7 @@ import XCTest
 *
 * @note The default timeout is two seconds.
 */
-extension XCTestCase {
+public extension XCTestCase {
     /**
     * Waits for the default timeout until `element.exists` is true.
     *


### PR DESCRIPTION
I would like to make this extension public so I can directly use it in
my projects.
